### PR TITLE
feat: create `wrapMultiPlugin` to allow wrapping plugins like `publish`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"
 after_success:
-  - npx semantic-release-github-pr
+  - "[[ $TRAVIS_PULL_REQUEST != 'false' ]] && npx semantic-release-github-pr"
   - npx semantic-release --debug

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,25 @@ const wrapPlugin = (namespace, type, fn) => {
   };
 };
 
+const wrapMultiPlugin = (namespace, type, fn) => {
+  let callCount = 0;
+
+  return Array(10).fill(async (pluginConfig, config) => {
+    const { [namespace]: { [type]: typeConfig } = {} } = pluginConfig;
+    const plugins = pluginsFromTypeConfig(typeConfig, type);
+
+    if (callCount >= plugins.length) {
+      return;
+    }
+
+    const plugin = plugins[callCount++];
+    return await fn(plugin)({ ...pluginConfig, ...typeConfig }, config);
+  });
+};
+
 module.exports = {
   pluginFromTypeConfig,
   pluginsFromTypeConfig,
   wrapPlugin,
+  wrapMultiPlugin,
 };

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,4 +1,4 @@
-const { pluginsFromTypeConfig, wrapPlugin } = require('.');
+const { pluginsFromTypeConfig, wrapPlugin, wrapMultiPlugin } = require('.');
 
 describe('Semantic Release Plugin Utils', () => {
   describe('#pluginsFromTypeConfig', () => {
@@ -65,6 +65,35 @@ describe('Semantic Release Plugin Utils', () => {
           await wrapPlugin(namespace, pluginType, plugin => ({ test }) => {
             expect(test).toBe(true);
           })(pluginConfig);
+        });
+      });
+    });
+  });
+
+  describe('#wrapMultiPlugin', () => {
+    const plugin = 'myPublish';
+    const namespace = 'monorepo';
+    const pluginType = 'publish';
+
+    describe('when passed a namespace, a plugin type and a decorator function', () => {
+      it('returns an array of 10 decorated functions', () => {
+        const decorator = () => {};
+        expect(wrapMultiPlugin(namespace, pluginType, decorator)).toHaveLength(
+          10
+        );
+      });
+    });
+
+    describe('and one of the returned decorated functions is passed a pluginConfig', () => {
+      describe(`and the config contains a "[namespace].[type]" plugin definition`, () => {
+        describe('and the array index of the decorated function matches', () => {
+          it('invokes the decorator with the matching plugin definition', async () => {
+            const decorator = plugin => (pluginConfig, config) => plugin;
+            const config = { [namespace]: { publish: plugin } };
+            const decorated = wrapMultiPlugin(namespace, pluginType, decorator);
+
+            expect(await decorated[0](config)).toBe(require(plugin));
+          });
         });
       });
     });


### PR DESCRIPTION
Presently, some `semantic-release` plugins can be defined as arrays of plugins. Wrapping requires a special approach because `semantic-release` handles that format differently internally, allowing for the plugins to be using a reducing function while running in sequence.

Trying to mimic the reducing function behavior introduces a lot of complexity and makes it difficult to guarantee the same behavior unless the code is lifted, which in turn is a direct dependency on the
internals of `semantic-release`. No thanks.

To work around this, we hook into the special treatment of arrays by defining the plugin as an array of decorated plugins. Since we don’t know beforehand how many plugins we’re expected to wrap, we use a size 10 array as a “catch all”. Any “unused” plugin wrappers are effectively a no-op.

The catch, as with `wrapPlugin`, is that any plugin-specific options have to be defined inside a namespace in the release config.