### PR TITLE
fix(semantic-release): loosen peer dependency restriction to >=11

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": "^11.1.0"
+    "semantic-release": ">=11"
   },
   "devDependencies": {
     "husky": "^0.14.3",


### PR DESCRIPTION
So far, the only thing assumed about `semantic-release` is the signature of a plugin function starting with [`semantic-release` 11](https://github.com/semantic-release/semantic-release/releases/tag/v11.0.0).