### PR TITLE
Append plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/__mocks__/defaultPlugin.js
+++ b/__mocks__/defaultPlugin.js
@@ -1,0 +1,1 @@
+module.exports = 'defaultPlugin';

--- a/__mocks__/defaultPublish.js
+++ b/__mocks__/defaultPublish.js
@@ -1,1 +1,0 @@
-module.exports = 'defaultPublish';

--- a/__mocks__/myPlugin.js
+++ b/__mocks__/myPlugin.js
@@ -1,0 +1,1 @@
+module.exports = 'myPlugin';

--- a/__mocks__/myPublish.js
+++ b/__mocks__/myPublish.js
@@ -1,1 +1,0 @@
-module.exports = 'myPublish';

--- a/src/index.js
+++ b/src/index.js
@@ -3,53 +3,75 @@ const importFrom = require('import-from');
 
 const requirePlugin = module => importFrom(process.cwd(), module);
 
-const pluginsFromTypeConfig = config =>
+/**
+ * @param definition Any valid `semantic-release` plugin format (`String`,
+ * `Object`, `Function` or `Array` of any of the former).
+ * @return {Array} List of resolved plugin(s) functions.
+ */
+const resolvePluginsFromDefinition = definition =>
   []
-    .concat((config && config.path) || config || [])
+    .concat((definition && definition.path) || definition || [])
     .filter(negate(isPlainObject))
     .map(value => (isFunction(value) ? value : requirePlugin(value)));
 
-const pluginFromTypeConfig = (config, type, index) =>
-  pluginsFromTypeConfig(config, type)[index];
-
-const resolvePluginFn = (config, type, _default = null, index = 0) => {
+/**
+ * @param type The name of the plugin type (e.g. "generateNotes").
+ * @param definition Any valid `semantic-release` plugin definition format
+ * (`String`, `Object`, `Function` or `Array` of any of the former).
+ * @param defaultDefinition A default plugin definition to fall back on if
+ * `definition` doesn't resolve to a plugin at the given index.
+ * @param index If the plugin definition is an array, the index of the plugin to
+ * resolve.
+ * @return plugin The resolved plugin function.
+ */
+const resolvePluginFn = (
+  type,
+  definition,
+  defaultDefinition = null,
+  index = 0
+) => {
   const plugin =
-    pluginFromTypeConfig(config, type, index) ||
-    (_default && requirePlugin(_default));
+    resolvePluginsFromDefinition(definition)[index] ||
+    (defaultDefinition && requirePlugin(defaultDefinition));
 
   return isPlainObject(plugin) ? plugin[type] : plugin;
 };
 
-const wrapPlugin = (namespace, type, fn, _default = null, index = 0) => {
+const wrapPlugin = (
+  namespace,
+  type,
+  fn,
+  defaultDefinition = null,
+  index = 0
+) => {
   return async (pluginConfig, context) => {
-    const { [namespace]: { [type]: typeConfig } = {} } = pluginConfig;
-    const plugin = resolvePluginFn(typeConfig, type, _default, index);
+    const { [namespace]: { [type]: definition } = {} } = pluginConfig;
+    const plugin = resolvePluginFn(type, definition, defaultDefinition, index);
 
-    if (!plugin || (Array.isArray(typeConfig) && typeConfig.length <= index)) {
+    if (!plugin || (Array.isArray(definition) && definition.length <= index)) {
       return;
     }
 
     return await fn(plugin)(
       {
         ...pluginConfig,
-        ...(isPlainObject(typeConfig) ? typeConfig : undefined),
+        ...(isPlainObject(definition) ? definition : undefined),
       },
       context
     );
   };
 };
 
-const wrapMultiPlugin = (namespace, type, fn, _default = []) => {
+const wrapMultiPlugin = (namespace, type, fn, defaultDefinition = []) => {
   return Array(10)
     .fill(null)
     .map((value, index) => {
-      return wrapPlugin(namespace, type, fn, _default[index], index);
+      return wrapPlugin(namespace, type, fn, defaultDefinition[index], index);
     });
 };
 
 module.exports = {
-  pluginFromTypeConfig,
-  pluginsFromTypeConfig,
+  resolvePluginsFromDefinition,
   wrapPlugin,
   wrapMultiPlugin,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const resolvePluginFn = (config, type, _default = null, index = 0) => {
 };
 
 const wrapPlugin = (namespace, type, fn, _default = null, index = 0) => {
-  return async (pluginConfig, config) => {
+  return async (pluginConfig, context) => {
     const { [namespace]: { [type]: typeConfig } = {} } = pluginConfig;
     const plugin = resolvePluginFn(typeConfig, type, _default, index);
 
@@ -34,7 +34,7 @@ const wrapPlugin = (namespace, type, fn, _default = null, index = 0) => {
         ...pluginConfig,
         ...(isPlainObject(typeConfig) ? typeConfig : undefined),
       },
-      config
+      context
     );
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,43 @@ const wrapMultiPlugin = (namespace, type, fn, defaultDefinition = []) => {
     });
 };
 
+const appendMultiPlugin = (
+  namespace,
+  type,
+  appendedPlugin,
+  defaultDefinition = []
+) => {
+  return Array(10)
+    .fill(null)
+    .map((value, index) => {
+      return async (pluginConfig, context) => {
+        const { [namespace]: { [type]: definition } = {} } = pluginConfig;
+        const plugin = resolvePluginFn(
+          type,
+          definition,
+          defaultDefinition,
+          index
+        );
+
+        const definitionsLength = definition
+          ? Array.isArray(definition) && definition.length
+          : Array.isArray(defaultDefinition) && defaultDefinition.length;
+
+        if (!plugin || definitionsLength <= index) {
+          if (index > 0 && definitionsLength === index) {
+            return appendedPlugin(pluginConfig, context);
+          } else {
+            return;
+          }
+        }
+
+        return plugin(pluginConfig, context);
+      };
+    });
+};
+
 module.exports = {
+  appendMultiPlugin,
   resolvePluginsFromDefinition,
   wrapPlugin,
   wrapMultiPlugin,

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const resolvePluginFn = (
 ) => {
   const plugin =
     resolvePluginsFromDefinition(definition)[index] ||
-    (defaultDefinition && requirePlugin(defaultDefinition));
+    resolvePluginsFromDefinition(defaultDefinition)[index];
 
   return isPlainObject(plugin) ? plugin[type] : plugin;
 };
@@ -66,7 +66,7 @@ const wrapMultiPlugin = (namespace, type, fn, defaultDefinition = []) => {
   return Array(10)
     .fill(null)
     .map((value, index) => {
-      return wrapPlugin(namespace, type, fn, defaultDefinition[index], index);
+      return wrapPlugin(namespace, type, fn, defaultDefinition, index);
     });
 };
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -139,6 +139,7 @@ describe('Semantic Release Plugin Utils', () => {
             plugin => {
               expect(plugin).toBe(require(defaultPlugin));
               done();
+              return () => {};
             },
             ['', defaultPlugin]
           )[1](pluginConfig);
@@ -201,6 +202,7 @@ describe('Semantic Release Plugin Utils', () => {
             plugin => {
               expect(plugin).toBe(require(plugin));
               done();
+              return () => {};
             },
             [defaultPlugin]
           )[0](pluginConfig);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,27 +1,29 @@
-const { pluginsFromTypeConfig, wrapPlugin, wrapMultiPlugin } = require('.');
+const { resolvePluginsFromDefinition, wrapPlugin, wrapMultiPlugin } = require('.');
 
 describe('Semantic Release Plugin Utils', () => {
-  describe('#pluginsFromTypeConfig', () => {
+  describe('#resolvePluginsFromDefinition', () => {
     describe('when passed a release config', () => {
       describe('and the config is empty/undefined/null', () => {
         it('returns an empty array', () => {
-          expect(pluginsFromTypeConfig({})).toEqual([]);
-          expect(pluginsFromTypeConfig(null)).toEqual([]);
-          expect(pluginsFromTypeConfig(undefined)).toEqual([]);
+          expect(resolvePluginsFromDefinition({})).toEqual([]);
+          expect(resolvePluginsFromDefinition(null)).toEqual([]);
+          expect(resolvePluginsFromDefinition(undefined)).toEqual([]);
         });
       });
 
       describe('and the config is a function', () => {
         it('returns an array with the function', () => {
           const fn = () => {};
-          expect(pluginsFromTypeConfig(fn)).toEqual([fn]);
+          expect(resolvePluginsFromDefinition(fn)).toEqual([fn]);
         });
       });
 
       describe('and the config is a string', () => {
         it('returns an array with the result of requiring the string', () => {
           const plugin = 'myPlugin';
-          expect(pluginsFromTypeConfig(plugin)).toEqual([require(plugin)]);
+          expect(resolvePluginsFromDefinition(plugin)).toEqual([
+            require(plugin),
+          ]);
         });
       });
 
@@ -30,7 +32,7 @@ describe('Semantic Release Plugin Utils', () => {
           const fn = () => {};
           const plugin = 'myPlugin';
 
-          expect(pluginsFromTypeConfig([fn, plugin])).toEqual([
+          expect(resolvePluginsFromDefinition([fn, plugin])).toEqual([
             fn,
             require(plugin),
           ]);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -20,7 +20,7 @@ describe('Semantic Release Plugin Utils', () => {
 
       describe('and the config is a string', () => {
         it('returns an array with the result of requiring the string', () => {
-          const plugin = 'myPublish';
+          const plugin = 'myPlugin';
           expect(pluginsFromTypeConfig(plugin)).toEqual([require(plugin)]);
         });
       });
@@ -28,7 +28,7 @@ describe('Semantic Release Plugin Utils', () => {
       describe('and the config is an array of functions and/or strings', () => {
         it('returns an array with the functions and/or required strings', () => {
           const fn = () => {};
-          const plugin = 'myPublish';
+          const plugin = 'myPlugin';
 
           expect(pluginsFromTypeConfig([fn, plugin])).toEqual([
             fn,
@@ -41,13 +41,13 @@ describe('Semantic Release Plugin Utils', () => {
 
   describe('#wrapPlugin', () => {
     describe('when passed a namespace, a plugin type and a decorator function', () => {
-      const plugin = 'myPublish';
+      const myPlugin = 'myPlugin';
       const namespace = 'monorepo';
-      const pluginType = 'publish';
+      const pluginType = 'analyzeCommits';
 
       describe('and the namespace/type combo has a plugin defined', () => {
         it('calls the decorator with plugin', async done => {
-          const pluginConfig = { [namespace]: { publish: plugin } };
+          const pluginConfig = { [namespace]: { [pluginType]: myPlugin } };
 
           await wrapPlugin(namespace, pluginType, plugin => {
             expect(plugin).toBe(require(plugin));
@@ -61,10 +61,10 @@ describe('Semantic Release Plugin Utils', () => {
 
         it(`decorates pluginOptions with the corresponding plugin's options`, async done => {
           const pluginConfig = {
-            [namespace]: { publish: { path: plugin, test: true } },
+            [namespace]: { [pluginType]: { path: myPlugin, test: true } },
           };
 
-          await wrapPlugin(namespace, pluginType, plugin => ({ test }) => {
+          await wrapPlugin(namespace, pluginType, () => ({ test }) => {
             expect(test).toBe(true);
             done();
           })(pluginConfig);
@@ -72,10 +72,10 @@ describe('Semantic Release Plugin Utils', () => {
       });
 
       describe(`and the namespace/type combo doesn't have a plugin defined`, () => {
-        const pluginConfig = { [namespace]: { publish: { test: true } } };
+        const pluginConfig = { [namespace]: { [pluginType]: { test: true } } };
 
         describe('and a default plugin was defined', () => {
-          const defaultPlugin = 'defaultPublish';
+          const defaultPlugin = 'defaultPlugin';
 
           it('calls the decorator with the default plugin', async () => {
             await wrapPlugin(
@@ -93,7 +93,7 @@ describe('Semantic Release Plugin Utils', () => {
             await wrapPlugin(
               namespace,
               pluginType,
-              plugin => ({ test }) => {
+              () => ({ test }) => {
                 expect(test).toBe(true);
                 done();
               },
@@ -114,10 +114,10 @@ describe('Semantic Release Plugin Utils', () => {
   });
 
   describe('#wrapMultiPlugin', () => {
-    const plugin = 'myPublish';
+    const myPlugin = 'myPlugin';
     const namespace = 'monorepo';
     const pluginType = 'publish';
-    const defaultPlugin = 'defaultPublish';
+    const defaultPlugin = 'defaultPlugin';
 
     describe('when passed a namespace, a plugin type and a decorator function', () => {
       it('returns an array of 10 decorated functions', () => {
@@ -155,7 +155,7 @@ describe('Semantic Release Plugin Utils', () => {
     });
 
     describe(`and the namespace/type combo defines an empty array`, () => {
-      const pluginConfig = { [namespace]: { publish: [] } };
+      const pluginConfig = { [namespace]: { [pluginType]: [] } };
 
       describe(`and a default plugin was defined for index X`, () => {
         it('does not invoke the decorator', async () => {
@@ -180,11 +180,11 @@ describe('Semantic Release Plugin Utils', () => {
     });
 
     describe('and the namespace/type combo has plugin(s) defined', () => {
-      const pluginConfig = { [namespace]: { publish: [plugin] } };
+      const pluginConfig = { [namespace]: { [pluginType]: [myPlugin] } };
 
       it('calls the decorator with the plugin', async done => {
         await wrapMultiPlugin(namespace, pluginType, plugin => {
-          expect(plugin).toBe(require(plugin));
+          expect(plugin).toBe(require(myPlugin));
 
           return typePluginConfig => {
             expect(typePluginConfig).toEqual(pluginConfig);


### PR DESCRIPTION
Allows adding a plugin to the end of a "multi plugin" definition. This will be necessary for `semantic-release-github-pr` to wrap `generateNotes` since the latter is now a "multi plugin". It doesn't want to wrap each individual plugin but rather perform an action with the result.