### PR TITLE
fix(deps): Limit semantic-release peer-dep to <20

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -12,4 +12,4 @@ jobs:
           node-version: 20
       # semantic-release dry-run workaround https://github.com/semantic-release/semantic-release/issues/1890#issuecomment-974512960
       - run: git checkout -b ${{ github.head_ref }}
-      - run: unset GITHUB_ACTIONS && yarn && yarn run semantic-release-github-pr --debug
+      - run: unset GITHUB_ACTIONS && npx semantic-release-github-pr --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - run: yarn && yarn run semantic-release --debug
+      - run: npx semantic-release --debug

--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": ">=11"
+    "semantic-release": ">=11 < 20"
   },
   "devDependencies": {
     "husky": "^4.2.1",
     "jest": "^25.1.0",
     "lint-staged": "^10.0.4",
-    "prettier": "^1.19.1",
-    "semantic-release": "^17.0.1",
-    "semantic-release-github-pr": "^6.0.0"
+    "prettier": "^1.19.1"
   },
   "dependencies": {},
   "husky": {


### PR DESCRIPTION
There is a breaking ESM change in `semantic-release` 20.